### PR TITLE
add `make fmt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,14 @@ lint: lint-python lint-rust
 .PHONY: test
 test:
 	cargo test
+
+.PHONY: fmt
+fmt: fmt-python fmt-rust
+
+.PHONY: fmt-python
+fmt-python:
+	black python
+
+.PHONY: fmt-rust
+fmt-rust:
+	cargo fmt


### PR DESCRIPTION
Run `make fmt` to format both python and rust sources.