### PR TITLE
Multiprocessing re-work for benchmark utility

### DIFF
--- a/benchmark/__main__.py
+++ b/benchmark/__main__.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import argparse
 import sys
 from datetime import datetime
@@ -39,4 +40,5 @@ def parse_args(args):
 
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method("spawn")
     main()

--- a/benchmark/manager.py
+++ b/benchmark/manager.py
@@ -90,9 +90,9 @@ class TestManager:
             # If a test have multiple instances, create one instance for each
             if cls.instances:
                 for params, _ in cls.instances:
-                    self.add_test_instance(cls(**params))
+                    self.add_test_instance(cls(self.session_dir, **params))
             else:
-                self.add_test_instance(cls())
+                self.add_test_instance(cls(self.session_dir))
 
         if self.debug:
             num_instances = len(self.test_instances)
@@ -120,7 +120,8 @@ class TestManager:
     def run(self):
         """Run all tests"""
         for instance in self.test_instances:
-            instance.run(self.session_dir)
+            instance.start()
+            instance.join()
 
     def create_graph(
         self,

--- a/benchmark/tests/arcade/collision.py
+++ b/benchmark/tests/arcade/collision.py
@@ -1,4 +1,5 @@
 import random
+from pathlib import Path
 
 import arcade
 
@@ -20,8 +21,9 @@ class Test(ArcadePerfTest):
     name = "collision"
     instances = (({"method": 3}, "Simple"),)
 
-    def __init__(self, method: int = DEFAULT_METHOD):
+    def __init__(self, session_dir: Path, method: int = DEFAULT_METHOD):
         super().__init__(
+            session_dir,
             size=(SCREEN_WIDTH, SCREEN_HEIGHT),
             title=SCREEN_TITLE,
             start_count=0,

--- a/benchmark/tests/arcade_accelerate/collision.py
+++ b/benchmark/tests/arcade_accelerate/collision.py
@@ -1,4 +1,8 @@
 import random
+from pathlib import Path
+
+import arcade_accelerate
+arcade_accelerate.bootstrap()
 
 import arcade
 
@@ -20,8 +24,9 @@ class Test(AcceleratedPerfTest):
     name = "collision"
     instances = (({"method": 3}, "Simple"),)
 
-    def __init__(self, method: int = DEFAULT_METHOD):
+    def __init__(self, session_dir: Path, method: int = DEFAULT_METHOD):
         super().__init__(
+            session_dir,
             size=(SCREEN_WIDTH, SCREEN_HEIGHT),
             title=SCREEN_TITLE,
             start_count=0,

--- a/src/sprite_list.rs
+++ b/src/sprite_list.rs
@@ -7,7 +7,9 @@ pub fn check_for_collision_with_list(
     py: Python<'_>,
     sprite: &PyAny, //
     sprite_list: &PyAny,
+    method: Option<i32>,
 ) -> Vec<PyObject> {
+    let _final_method = method.unwrap_or(3);
     let mut final_sprites: Vec<PyObject> = Vec::new();
 
     let mut hitbox1: Option<HitBox> = None;


### PR DESCRIPTION
Reworked the benchmarking utility to run each test as it's own process(and specifically spawning a new process, not forking). This gives us better isolation in each process, especially considering the nature of the importing and monkeypatching we do within arcade-accelerate. This ensures that each test can run with a completely fresh slate of a python interpreter.